### PR TITLE
Merge all working changes under 'coap-as-jpy' branch into 'main'

### DIFF
--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -77,14 +77,18 @@ informative:
 
 --- abstract
 This document extends the work of Bootstrapping Remote Secure Key
-Infrastructures (BRSKI) by replacing the Circuit-proxy between
-Pledge and Registrar by a stateless/stateful constrained Join
-Proxy. The constrained Join Proxy is a mesh neighbor of the
+Infrastructures (BRSKI) by replacing the (stateful) TLS Circuit proxy between
+Pledge and Registrar with a stateless or stateful Circuit proxy using CoAP
+which is called the constrained Join Proxy. The constrained Join Proxy is a mesh neighbor of the
 Pledge and can relay a DTLS session originating from a Pledge with only link-local
 addresses to a Registrar which is not a mesh neighbor of the
 Pledge.
 
-This document defines a protocol to securely assign a Pledge to a domain, represented by a Registrar, using an intermediary node between Pledge and Registrar. This intermediary node is known as a "constrained Join Proxy". An enrolled Pledge can act as a constrained Join Proxy.
+Like the BRSKI Circuit proxy, this constrained Join Proxy eliminates the need of
+Pledges to have routeable IP addresses before enrolment by utilizing link-local
+addresses. Use of the constrained Join Proxy also eliminates the need of the Pledge 
+to authenticate to the network or perform network-wide Registrar discover before enrolment.
+
 --- middle
 
 # Introduction

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -168,11 +168,11 @@ Registrar/Coordinator (JRC)".
 
 The term "installation" refers to all devices in the network and their interconnections, including Registrar, enrolled nodes with and without constrained Join Proxy functionality and Pledges.
 
-(Installation) IP addresses are assumed to be routeable over the whole installation network except for link-local IP addresses.
+(Installation) IP addresses are assumed to be routeable over the whole installation network except for the link-local IP addresses used at the edges where new pledges join.
 
-The "Constrained Join Proxy" enables a pledge that is multiple hops away from the Registrar, to securely execute the BRSKI protocol {{RFC8995}} over a secure channel.
+The "Constrained Join Proxy" enables a pledge that is multiple hops away from the Registrar, to execute the BRSKI protocol {{RFC8995}} using a secure channel.
 
-The term "join Proxy" is used interchangeably with the term "constrained Join Proxy" throughout this document.
+The term "Join Proxy" is used interchangeably with the term "constrained Join Proxy" throughout this document.
 
 The {{RFC8995}} Circuit Proxy is referred to as a TCP circuit Join Proxy.
 
@@ -181,8 +181,8 @@ The {{RFC8995}} Circuit Proxy is referred to as a TCP circuit Join Proxy.
 As depicted in the {{fig-net}}, the Pledge (P), in a network such as a Low-Power and Lossy Network (LLN) mesh
  {{RFC7102}} can be more than one hop away from the Registrar (R) and not yet authenticated into the network.
 
-In this situation, the Pledge can only communicate one-hop to its nearest neighbor, the constrained Join Proxy (J) using their link-local IPv6 addresses.
-However, the Pledge needs to communicate with end-to-end security with a Registrar to authenticate and get the relevant system/network parameters.
+In this situation, the Pledge can only communicate one-hop to its nearest neighbor, the constrained Join Proxy (J) using link-local IPv6 addresses.
+However, the Pledge needs to communicate using end-to-end security with a Registrar in order to onboard, authenticate and get the relevant system/network parameters.
 If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connection to the Registrar, then the packets are dropped at the constrained Join Proxy since the Pledge is not yet admitted to the network or there is no IP routability to the Pledge for any returned messages from the Registrar.
 
 ~~~~ aasvg

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -201,28 +201,39 @@ If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connect
 Without a routeable IPv6 address, the Pledge (P) cannot exchange IPv6/UDP/DTLS traffic
 with the Registrar (R), over multiple hops in the network.
 
-Furthermore, the Pledge may not be able to discover the IP address of the Registrar over multiple hops to initiate a DTLS connection and perform authentication.
+Furthermore, the Pledge may not even be able to discover the IP address of the Registrar over multiple hops to initiate a DTLS connection and perform authentication.
 
-To overcome the problems with non-routability of DTLS packets and/or discovery of the destination address of the Registrar, the constrained Join Proxy is introduced.
-This constrained Join Proxy functionality is also (auto) configured into all authenticated devices in the network which may act as a constrained Join Proxy for Pledges.
-The constrained Join Proxy allows for routing of the packets from the Pledge using IP routing to the intended Registrar. An authenticated constrained Join Proxy can discover the routable IP address of the Registrar over multiple hops.
-The following {{jr-spec}} specifies the two constrained Join Proxy modes. A comparison is presented in {{jr-comp}}.
+To overcome the problems with non-routability of DTLS packets and the discovery of the destination address of the Registrar, the constrained Join Proxy is introduced.
+This constrained Join Proxy functionality is also (auto) configured into all authenticated devices in the network which may act as a constrained Join Proxy for
+Pledges.
 
-When a mesh network is set up, it consists of a Registrar and a set of connected pledges. No constrained Join Proxies are present.  Only some of these pledges may be neighbors of the Registrar. Others would need for their traffic to be routed across one or more enrolled devices to reach the Registrar.
+The constrained Join Proxy allows for routing of the packets from the Pledge using IP routing to the intended Registrar.
+An authenticated constrained Join Proxy can discover the routable IP address of the Registrar over multiple hops.
+The following {{jr-spec}} specifies the two constrained Join Proxy modes.
+A comparison is presented in {{jr-comp}}.
 
-The desired state of the installation is a network with a Registrar and all Pledges becoming enrolled devices. Some of these enrolled devices can act as constrained Join Proxies. Pledges can only employ link-local communication until they are enrolled. A Pledge will regularly try to discover a constrained Join Proxy or a Registrar with link-local discovery requests. The Pledges which are neighbors of the Registrar will discover the Registrar and be enrolled following the constrained BRSKI protocol. An enrolled device can act as constrained Join Proxy. The Pledges which are not a neighbor of the Registrar will eventually discover a constrained Join Proxy and follow the constrained BRSKI protocol to be enrolled. While this goes on, more and more constrained Join Proxies with a larger hop distance to the Registrar will emerge. The network should be configured such that at the end of the enrollment process, all pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
+When a mesh network is set up, it consists of a Registrar and a set of connected pledges.
+No constrained Join Proxies are present.
+Only some of these pledges may be neighbors of the Registrar.
+Others would need for their traffic to be routed across one or more enrolled devices to reach the Registrar.
 
-The constrained Join Proxy is as a packet-by-packet proxy for UDP packets between Pledge and
-Registrar. The constrained BRSKI protocol between Pledge and Registrar described in
-{{I-D.ietf-anima-constrained-voucher}} which this Join Proxy supports
-uses UDP messages with DTLS payload, but the Join Proxy as described here is unaware
-of this payload. It can therefore potentially also work for other UDP based protocols
-as long as they are agnostic to (or can be made to work with) the change of IP header
-by the constrained Join Proxy.
+The desired state of the installation is a network with a Registrar and all Pledges becoming enrolled devices.
+Some of these enrolled devices can act as constrained Join Proxies.
+Pledges can only employ link-local communication until they are enrolled.
+A Pledge will regularly try to discover a constrained Join Proxy or a Registrar with link-local discovery requests.
+The Pledges which are neighbors of the Registrar will discover the Registrar and be enrolled following the constrained BRSKI protocol.
+An enrolled device can act as constrained Join Proxy.
+The Pledges which are not a neighbor of the Registrar will eventually discover a constrained Join Proxy and follow the constrained BRSKI protocol to be enrolled.
+While this goes on, more and more constrained Join Proxies with a larger hop distance to the Registrar will emerge.
+The network should be configured such that at the end of the enrollment process, all pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
+
+The constrained Join Proxy is as a packet-by-packet proxy for UDP packets between Pledge and Registrar.
+The constrained BRSKI protocol between Pledge and Registrar described in {{I-D.ietf-anima-constrained-voucher}} which this Join Proxy supports uses UDP messages with DTLS payload, but the Join Proxy as described here is unaware of this payload.
+It can therefore potentially also work for other UDP based protocols as long as they are agnostic to (or can be made to work with) the change of IP header by the constrained Join Proxy.
 
 In both Stateless and Stateful mode, the Join Proxy needs to be configured with
-or dynamically discover a Registrar to perform its service. This specification does not
-discuss how a constrained Join Proxy selects a Registrar when it discovers 2 or more.
+or dynamically discover a Registrar to perform its service.
+This specification does not discuss how a constrained Join Proxy selects a Registrar when it discovers 2 or more.
 
 # constrained Join Proxy specification {#jr-spec}
 
@@ -233,35 +244,27 @@ A Join Proxy can operate in two modes:
 
 The advantages and disadvantages of the two modes are presented in {{jr-comp}}.
 
-A Join Proxy MUST implement both. A Registrar MUST implement the stateful mode and SHOULD implement the Stateless mode.
+A Join Proxy MUST implement both.
+A Registrar MUST implement the stateful mode and SHOULD implement the Stateless mode.
 
 For a Join Proxy to be operational, the node on which it is running has to be
-able to talk to a Registrar (exchange UDP messages with it). This can happen
-fully automatically by the Join Proxy node first enrolling itself as a Pledge,
-and then learning the IP address, the UDP port and the mode(s) (Stateful and/or Stateless)
-of the Registrar, through a discovery mechanism such as those described in Section 6.
-Other methods, such as provisioning the Join Proxy are out of scope of this document
-but equally feasible.
+able to talk to a Registrar (exchange UDP messages with it).
+This can happen fully automatically by the Join Proxy node first enrolling itself as a Pledge, and then learning the IP address, the UDP port and the mode(s) (Stateful and/or Stateless) of the Registrar, through a discovery mechanism such as those described in Section 6.
+Other methods, such as provisioning the Join Proxy are out of scope of this document but equally feasible.
 
 Once the Join Proxy is operational, its mode is determined by the mode of the Registrar.
-If the Registrar offers both Stateful and Stateless mode, the Join Proxy MUST use
-the stateless mode.
+If the Registrar offers both Stateful and Stateless mode, the Join Proxy MUST use the stateless mode.
 
-Independent of the mode of the Join Proxy, the Pledge first discovers (see Section 6)
-and selects the most appropriate Join Proxy. From the discovery, the Pledge learns the
-Join Proxies link-local scope IP address and UDP (join) port.  This discovery can also be
-based upon {{RFC8995}} section 4.1.  If the discovery method does not support discovery
-of the join-port, then the Pledge assumes the default CoAP over DTLS UDP port (5683).
+Independent of the mode of the Join Proxy, the Pledge first discovers (see Section 6) and selects the most appropriate Join Proxy.
+From the discovery, the Pledge learns the Join Proxies link-local scope IP address and UDP (join) port.
+This discovery can also be based upon {{RFC8995}} section 4.1.
+If the discovery method does not support discovery of the join-port, then the Pledge assumes the default CoAP over DTLS UDP port (5683).
 
 ## Stateful Join Proxy {#stateful}
 
-In stateful mode, the Join Proxy acts as a UDP "circuit" proxy that does not
-change the UDP payload (data octets according to {{RFC768}}) but only rewrites
-the IP and UDP headers of each packet it receives from Pledge and Registrar.
+In stateful mode, the Join Proxy acts as a UDP "circuit" proxy that does not change the UDP payload (data octets according to {{RFC768}}) but only rewrites the IP and UDP headers of each packet it receives from Pledge and Registrar.
 
-The stateful join proxy operates as a 'pseudo' UDP circuit proxy creating
-and utilizing connection mapping state to rewrite the IP address and UDP port number
-packet header fields of UDP packets that it forwards between Pledge and Registrar.
+The stateful join proxy operates as a 'pseudo' UDP circuit proxy creating and utilizing connection mapping state to rewrite the IP address and UDP port number packet header fields of UDP packets that it forwards between Pledge and Registrar.
 {{fig-statefull2}} depiects how this state is used.
 
 ~~~~
@@ -292,33 +295,24 @@ IP_Jr:p_Jr = Routable IP address and client port of Join Proxy
 ~~~~
 {: #fig-statefull2 title='constrained stateful joining message flow with Registrar address known to Join Proxy.' align="left"}
 
-Because UDP does not have the notion of a connection, this document
-calls this a 'pseudo' connection, whose establishment is solely
-triggered by receipt of a packet from a pledge with an
-IP_p%IF:p_P source for which no mapping state exists, and that is
+Because UDP does not have the notion of a connection, this document calls this a 'pseudo' connection, whose establishment is solely triggered by receipt of a packet from a pledge with an IP_p%IF:p_P source for which no mapping state exists, and that is
 termined by a connection expiry timer E.
 
 If an untrusted Pledge that can only use link-local addressing wants to contact a trusted Registrar, and the Registrar is more than one hop away, it sends its DTLS messages to the Join Proxy.
 
 ## Stateless Join Proxy {#jpy-encapsulation-protocol}
 
-Stateless join proxy operation eliminates the need and complexity to
-maintain per UDP connection mapping state on the proxy and the state machinery to build, maintain and
-remove this mapping state. It also removes the need to protect this mapping staate
-against DoS attacks and may also reduce memory and CPU requirements on the proxy.
+Stateless join proxy operation eliminates the need and complexity to maintain per UDP connection mapping state on the proxy and the state machinery to build, maintain and
+remove this mapping state.
+It also removes the need to protect this mapping staate against DoS attacks and may also reduce memory and CPU requirements on the proxy.
 
 Stateless join proxy operations works by introducing a new JPY message payload for messages between Proxy and Registrar, which consists of two parts:
 
   * Header (H) field: the link-local IP address, interface and UDP (source) port of the Pledge (P).
   * Contents (C) field: the original UDP payload (data octets according to RFC768).
 
-When  the join proxy receives a UDP message from a Pledge, it encodes the Pledges
-link-local IP address, interface and UDP (source) port of the packet into the Header field
-and the UDP payload into the Content field and sends the packet to the Registrar from
-a fixed source UDP port. When the Registrar sends packets for the Pledge,
-it MUST return the Header field unchanged, so that the join proxy can decode the
-Header to reconstruct the Pledges link-local IP address, interace and UDP (destination) port
-for the return packet. {{fig-stateless}} shows this per-packet mapping on the join proxy.
+When  the join proxy receives a UDP message from a Pledge, it encodes the Pledges link-local IP address, interface and UDP (source) port of the packet into the Header field and the UDP payload into the Content field and sends the packet to the Registrar from a fixed source UDP port.
+When the Registrar sends packets for the Pledge, it MUST return the Header field unchanged, so that the join proxy can decode the Header to reconstruct the Pledges link-local IP address, interace and UDP (destination) port for the return packet. {{fig-stateless}} shows this per-packet mapping on the join proxy.
 
 The Registrar transiently stores the Header field information.
 The Registrar uses the Contents field to execute the Registrar functionality.
@@ -329,14 +323,8 @@ The Header contains the original source link-local address and port of the Pledg
 On receiving the JPY message, the Join Proxy retrieves the two parts.
 It uses the Header field to route the DTLS message containing the DTLS payload retrieved from the Contents field to the Pledge.
 
-When the Registrar receives such a JPY message, it MUST treat the Header
-H as a single additional opaque identifier for all packets of a UDP connection
-from a Plege: Whereas in the stateful proxy case, all packets with the same
-(IP_jr:p_Jr, IP_R:p_r) belong to a single Pledges UDP connection and hence
-DTLS/CoAP connection, only the packets with the same (IP_jr:p_Jr, IP_R:p_r, H)
-belong to a single Plegdes UDP connection / DTLS/CoAP connection. The
-JPY Content field payload is the UDP payload of the packet for that UDP
-connection. Packets with different H belong to different Pledges UDP connections.
+When the Registrar receives such a JPY message, it MUST treat the Header H as a single additional opaque identifier for all packets of a UDP connection from a Plege: Whereas in the stateful proxy case, all packets with the same (IP_jr:p_Jr, IP_R:p_r) belong to a single Pledges UDP connection and hence DTLS/CoAP connection, only the packets with the same (IP_jr:p_Jr, IP_R:p_r, H) belong to a single Plegdes UDP connection / DTLS/CoAP connection.
+The JPY Content field payload is the UDP payload of the packet for that UDP connection. Packets with different H belong to different Pledges UDP connections.
 
 In the stateless join proxy mode, both the Registrar and the Join Proxy use discoverable UDP join-ports. For the Join Proxy this may be a default CoAP port.
 
@@ -456,7 +444,7 @@ In order to accomodate automatic configuration of the Join-Proxy, it must discov
 ### CoAP discovery {#coap-disc}
 
 {{Section 10.2.2 of I-D.ietf-anima-constrained-voucher}} describes how to use CoAP Discovery.
-The stateless Join Proxy requires a different end point that can accept the JPY encapsulation.
+The stateless Join Proxy requires a different end point that can accept the JPYencapsulation.
 
 The stateless Join Proxy can discover the join-port of the Registrar by sending a GET request to "/.well-known/core" including a resource type (rt) parameter with the value "brski.rjp" {{RFC6690}}.
 Upon success, the return payload will contain the join-port of the Registrar.
@@ -536,11 +524,10 @@ When doing constrained onboarding with DTLS as security, the Pledge will always 
 ### CoAP discovery {#jp-disc}
 
 In the context of a coap network without Autonomic Network support, discovery follows the standard coap policy.
-The Pledge can discover a Join Proxy by sending a link-local multicast message to ALL CoAP Nodes with address FF02::FD. Multiple or no nodes may respond. The handling of multiple responses and the absence of responses follow section 4 of {{RFC8995}}.
+The Pledge can discover a Join Proxy by sending a link-local multicast message to ALL CoAP Nodes with address FF02::FD. Multiple or no nodes may respond.
+The handling of multiple responses and the absence of responses follow section 4 of {{RFC8995}}.
 
-The join-port of the Join Proxy is discovered by
-sending a GET request to "/.well-known/core" including a resource type (rt)
-parameter with the value "brski.jp" {{RFC6690}}.
+The join-port of the Join Proxy is discovered by sending a GET request to "/.well-known/core" including a resource type (rt) parameter with the value "brski.jp" {{RFC6690}}.
 Upon success, the return payload will contain the join-port.
 
 The example below shows the discovery of the join-port of the Join Proxy.
@@ -586,9 +573,8 @@ The discovery of Join-Proxy by the Pledge uses the enhanced beacons as discussed
 
 # Comparison of stateless and stateful modes {#jr-comp}
 
-The stateful and stateless mode of operation for the Join Proxy have
-their advantages and disadvantages.
-This section should enable operators to make a choice between the two modes based  on the available device resources and network bandwidth.
+The stateful and stateless mode of operation for the Join Proxy have their advantages and disadvantages.
+This section should enable operators to make a choice between the two modes based on the available device resources and network bandwidth.
 
 ~~~~
 +-------------+----------------------------+------------------------+
@@ -638,18 +624,31 @@ A malicious constrained Join Proxy has a number of routing possibilities:
 
    * It uses the request from the pledge to appropriate the pledge certificate, but then it still needs to acquire the private key of the pledge. This, too, is assumed to be highly unlikely.
 
-   * A malicious node can construct an invalid Join Proxy message. Suppose, the destination port is the coaps port. In that case, a Join Proxy can accept the message and add the routing addresses without checking the payload. The Join Proxy then routes it to the Registrar. In all cases, the Registrar needs to receive the message at the join-port, checks that the message consists of two parts and uses the DTLS payload to start the BRSKI procedure. It is highly unlikely that this malicious payload will lead to node acceptance.
+   * A malicious node can construct an invalid Join Proxy message.
+Suppose, the destination port is the coaps port.
+In that case, a Join Proxy can accept the message and add the routing addresses without checking the payload.
+The Join Proxy then routes it to the Registrar.
+In all cases, the Registrar needs to receive the message at the join-port, checks that the message consists of two parts and uses the DTLS payload to start the BRSKI procedure.
+It is highly unlikely that this malicious payload will lead to node acceptance.
 
-  * A malicious node can sniff the messages routed by the constrained Join Proxy. It is very unlikely that the malicious node can decrypt the DTLS payload. A malicious node can read the header field of the message sent by the stateless Join Proxy. This ability does not yield much more information than the visible addresses transported in the network packets.
+  * A malicious node can sniff the messages routed by the constrained Join Proxy.
+It is very unlikely that the malicious node can decrypt the DTLS payload.
+A malicious node can read the header field of the message sent by the stateless Join Proxy.
+This ability does not yield much more information than the visible addresses transported in the network packets.
 
-It should be noted here that the contents of the CBOR array used to convey return address information is not DTLS protected. When the communication between JOIN Proxy and Registrar passes over an unsecure network, an attacker can change the CBOR array, causing the Registrar to deviate traffic from the intended Pledge. These concerns are also expressed in {{RFC8974}}. It is also pointed out that the encryption in the source is a local matter. Similarly to {{RFC8974}}, the use of AES-CCM {{RFC3610}} with a 64-bit tag is recommended, combined with a sequence number and a replay window.
+It should be noted here that the contents of the CBOR array used to convey return address information is not DTLS protected.
+When the communication between JOIN Proxy and Registrar passes over an unsecure network, an attacker can change the CBOR array, causing the Registrar to deviate traffic from the intended Pledge.
+These concerns are also expressed in {{RFC8974}}.
+It is also pointed out that the encryption in the source is a local matter.
+Similarly to {{RFC8974}}, the use of AES-CCM {{RFC3610}} with a 64-bit tag is recommended, combined with a sequence number and a replay window.
 
-If such scenario needs to be avoided, the constrained Join
-Proxy MUST encrypt the CBOR array using a locally generated symmetric
-key. The Registrar is not able to examine the encrypted result, but
-does not need to. The Registrar stores the encrypted header in the return packet without modifications. The constrained Join Proxy can decrypt the contents to route the message to the right destination.
+If such scenario needs to be avoided, the constrained Join Proxy MUST encrypt the CBOR array using a locally generated symmetric key.
+The Registrar is not able to examine the encrypted result, but does not need to.
+The Registrar stores the encrypted header in the return packet without modifications.
+The constrained Join Proxy can decrypt the contents to route the message to the right destination.
 
-In some installations, layer 2 protection is provided between all member pairs of the mesh. In such an environment encryption of the CBOR array is unnecessary because the layer 2 protection already provide it.
+In some installations, layer 2 protection is provided between all member pairs of the mesh.
+In such an environment encryption of the CBOR array is unnecessary because the layer 2 protection already provide it.
 
 # IANA Considerations
 
@@ -687,8 +686,7 @@ Parameters" registry per the {{RFC6690}} procedure.
 
 ## service name and port number registry {#dns-sd-spec}
 
-This specification registers two service names under the "Service Name and Transport Protocol Port
-Number" registry.
+This specification registers two service names under the "Service Name and Transport Protocol Port Number" registry.
 
     Service Name: brski-jp
     Transport Protocol(s): udp

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -86,7 +86,7 @@ Pledge.
 
 Like the BRSKI Circuit proxy, this constrained Join Proxy eliminates the need of
 Pledges to have routeable IP addresses before enrolment by utilizing link-local
-addresses. Use of the constrained Join Proxy also eliminates the need of the Pledge 
+addresses. Use of the constrained Join Proxy also eliminates the need of the Pledge
 to authenticate to the network or perform network-wide Registrar discover before enrolment.
 
 --- middle
@@ -97,9 +97,9 @@ The Bootstrapping Remote Secure Key Infrastructure (BRSKI) protocol described in
 provides a solution for a secure zero-touch (automated) bootstrap of new (unconfigured) devices.
 In the context of BRSKI, new devices, called "Pledges", are equipped with a factory-installed Initial Device Identifier (IDevID) (see {{ieee802-1AR}}), and are enrolled into a network.
 BRSKI makes use of Enrollment over Secure Transport (EST) {{RFC7030}}
-with {{RFC8366}} vouchers to securely enroll devices. A Registrar provides the security anchor of the network to which a Pledge enrolls. 
+with {{RFC8366}} vouchers to securely enroll devices. A Registrar provides the security anchor of the network to which a Pledge enrolls.
 
-In this document, BRSKI is extended such that a Pledge connects to "Registrars" via a constrained Join Proxy. 
+In this document, BRSKI is extended such that a Pledge connects to "Registrars" via a constrained Join Proxy.
 In particular, this solution is intended to support mesh networks as described in {{RFC4944}}.
 
 The constrained Join Proxy as specified in this document is one of the Join Proxy

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -133,12 +133,16 @@ one or more hops.
 
 An enrolled Pledge can act as constrained Join Proxy between other Pledges and the enrolling Registrar.
 
-This document specifies a new form of constrained Join Proxy and protocol to act as intermediary between Pledge and Registrar to relay DTLS messages between Pledge and Registrar. Two modes of the constrained Join Proxy are specified:
+Two modes of the constrained Join Proxy are specified:
 
-    1 A stateful Join Proxy that locally stores IP addresses
+    1 A stateful Join Proxy that locally stores UDP connection state:
+      IP addresses (link-local with interface and non-link-local and UDP port-numbers)
       during the connection.
-    2 A stateless Join Proxy where the connection state
-     is stored in the messages.
+
+    2 A stateless Join Proxy where the connection the state
+      is placed into a new header in the
+      UDP messages between constrained Join Proxy and Registrar.
+
 
 This document is very much inspired by text published earlier in {{I-D.kumar-dice-dtls-relay}}.
 {{I-D.richardson-anima-state-for-joinrouter}} outlined the various options for building a constrained Join Proxy.

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -114,24 +114,22 @@ CoAP can be run with the Datagram Transport Layer Security (DTLS) {{RFC6347}} as
 This is known as the "coaps" scheme.
 A constrained version of EST, using Coap and DTLS, is described in {{RFC9148}}.
 
-The {{I-D.ietf-anima-constrained-voucher}} extends {{RFC9148}} with BRSKI artifacts such as voucher, request voucher, and the protocol extensions for constrained Pledges.
+The {{I-D.ietf-anima-constrained-voucher}} extends {{RFC9148}} with BRSKI artifacts such as voucher, request voucher, and the protocol extensions for constrained Pledges that use CoAP.
 
-DTLS is a client-server protocol relying on the underlying IP layer to perform the routing between the DTLS Client and the DTLS Server.
-However, the Pledge will not be IP routable over the mesh network
+However, in networks that require authentication, such as those using {{RFC4944}},
+the Pledge will not be IP routable over the mesh network
 until it is authenticated to the mesh network. A new Pledge can only
 initially use a link-local IPv6 address to communicate with a
 mesh neighbor [RFC6775] until it receives the necessary network
 configuration parameters. The Pledge receives these configuration
 parameters from the Registrar. When the Registrar is not a direct
 neighbor of the Registrar but several hops away, the Pledge
-discovers a neighbor constrained Join Proxy, which transmits the DTLS
-protected request coming from the Pledge
-to the Registrar. The constrained Join Proxy must be enrolled
+discovers a neighbor that is operating the constrained Join Proxy, which
+forwards DTLS protected messages between Pledge and Registrar.
+The constrained Join Proxy must be enrolled
 previously such that the
 message from constrained Join Proxy to Registrar can be routed over
 one or more hops.
-
-During enrollment, a DTLS connection is required between Pledge and Registrar.
 
 An enrolled Pledge can act as constrained Join Proxy between other Pledges and the enrolling Registrar.
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -97,7 +97,13 @@ The Bootstrapping Remote Secure Key Infrastructure (BRSKI) protocol described in
 provides a solution for a secure zero-touch (automated) bootstrap of new (unconfigured) devices.
 In the context of BRSKI, new devices, called "Pledges", are equipped with a factory-installed Initial Device Identifier (IDevID) (see {{ieee802-1AR}}), and are enrolled into a network.
 BRSKI makes use of Enrollment over Secure Transport (EST) {{RFC7030}}
-with {{RFC8366}} vouchers to securely enroll devices. A Registrar provides the security anchor of the network to which a Pledge enrolls. In this document, BRSKI is extended such that a Pledge connects to "Registrars" via a constrained Join Proxy. In particular, the underlying IP network is assumed to be a mesh network as described in {{RFC4944}}, although other IP-over-foo networks are not excluded. An example network is shown in {{fig-net}}.
+with {{RFC8366}} vouchers to securely enroll devices. A Registrar provides the security anchor of the network to which a Pledge enrolls. 
+
+In this document, BRSKI is extended such that a Pledge connects to "Registrars" via a constrained Join Proxy. 
+In particular, this solution is intended to support mesh networks as described in {{RFC4944}}.
+
+The constrained Join Proxy as specified in this document is one of the Join Proxy
+options referred to in {{RFC8995}} section 2.5.2 as future work.
 
 A complete specification of the terminology is pointed at in {{Terminology}}.
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -191,10 +191,10 @@ If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connect
 
 ~~~~ aasvg
                     multi-hop mesh
-         .---.
-         | R +---.    +----+    +---+        +--+
+         .---.                         IPv6
+         | R +---.    +----+    +---+ subnet +--+
          |   |    \   |6LR +----+ J |........|P |
-         '---'     `--+    |    |   |  clear |  |
+         '---'     `--+    |    |   | clear  |  |
                       +----+    +---+        +--+
        Registrar             Join Proxy     Pledge
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -140,7 +140,7 @@ Two modes of the constrained Join Proxy are specified:
       during the connection.
 
     2 A stateless Join Proxy where the connection state
-      is replaced by a new proxy header in the
+      is replaced by a second layer of CoAP header in the
       UDP messages between constrained Join Proxy and Registrar.
 
 
@@ -148,12 +148,12 @@ This document is very much inspired by text published earlier in {{I-D.kumar-dic
 {{I-D.richardson-anima-state-for-joinrouter}} outlined the various options for building a constrained Join Proxy.
 {{RFC8995}} adopted only the Circuit Proxy method (1), leaving the other methods as future work.
 
-Similar to the difference between storing and non_storing Modes of
+Similar to the difference between storing and non-storing Modes of
 Operations (MOP) in RPL {{RFC6550}}, the stateful and stateless modes differ in the way that they store
 the state required to forward the return packet to the pledge.
 In the stateful method, the
-return forward state is stored in the join proxy.  In the stateless
-method, the return forward state is stored in the network.
+return forward state is stored in the join proxy.
+In the stateless method, the return forward state is stored in the network using the CoAP extended token in a way identical to that described in {{RFC9031}}.
 
 # Terminology          {#Terminology}
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -139,8 +139,8 @@ Two modes of the constrained Join Proxy are specified:
       IP addresses (link-local with interface and non-link-local and UDP port-numbers)
       during the connection.
 
-    2 A stateless Join Proxy where the connection the state
-      is placed into a new header in the
+    2 A stateless Join Proxy where the connection state
+      is replaced by a new proxy header in the
       UDP messages between constrained Join Proxy and Registrar.
 
 
@@ -163,8 +163,6 @@ Registrar/Coordinator (JRC), Pledge, and Voucher.
 
 In this document, the term "Registrar" is used throughout instead of "Join
 Registrar/Coordinator (JRC)".
-
-The term "installation network" refers to all devices in the installation and the network connections between them. The term "installation IP_address" refers to an address out of the set of addresses which are routable over the whole installation network.
 
 The term "installation" refers to all devices in the network and their interconnections, including Registrar, enrolled nodes with and without constrained Join Proxy functionality and Pledges.
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -182,12 +182,12 @@ The {{RFC8995}} Circuit Proxy is referred to as a TCP circuit Join Proxy.
 
 # constrained Join Proxy functionality
 
-As depicted in the {{fig-net}}, the Pledge (P), in a Low-Power and Lossy Network (LLN) mesh
+As depicted in the {{fig-net}}, the Pledge (P), in a network such as a Low-Power and Lossy Network (LLN) mesh
  {{RFC7102}} can be more than one hop away from the Registrar (R) and not yet authenticated into the network.
 
 In this situation, the Pledge can only communicate one-hop to its nearest neighbor, the constrained Join Proxy (J) using their link-local IPv6 addresses.
 However, the Pledge needs to communicate with end-to-end security with a Registrar to authenticate and get the relevant system/network parameters.
-If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connection to the Registrar, then the packets are dropped at the constrained Join Proxy since the Pledge is not yet admitted to the network or there is no IP routability to Pledge for any returned messages from the Registrar.
+If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connection to the Registrar, then the packets are dropped at the constrained Join Proxy since the Pledge is not yet admitted to the network or there is no IP routability to the Pledge for any returned messages from the Registrar.
 
 ~~~~ aasvg
                     multi-hop mesh

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -166,9 +166,15 @@ Registrar/Coordinator (JRC)".
 
 The term "installation network" refers to all devices in the installation and the network connections between them. The term "installation IP_address" refers to an address out of the set of addresses which are routable over the whole installation network.
 
+The term "installation" refers to all devices in the network and their interconnections, including Registrar, enrolled nodes with and without constrained Join Proxy functionality and Pledges.
+
+(Installation) IP addresses are assumed to be routeable over the whole installation network except for link-local IP addresses.
+
 The "Constrained Join Proxy" enables a pledge that is multiple hops away from the Registrar, to securely execute the BRSKI protocol {{RFC8995}} over a secure channel.
 
 The term "join Proxy" is used interchangeably with the term "constrained Join Proxy" throughout this document.
+
+The {{RFC8995}} Circuit Proxy is referred to as a TCP circuit Join Proxy.
 
 # Requirements Language {#reqlang}
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -3,7 +3,7 @@ v: 3
 
 title: Constrained Join Proxy for Bootstrapping Protocols
 abbrev: Join Proxy
-docname: draft-ietf-anima-constrained-join-proxy-12
+docname: draft-ietf-anima-constrained-join-proxy-13
 
 # stand_alone: true
 
@@ -39,7 +39,6 @@ normative:
   RFC6347:
   RFC8366:
   RFC8995:
-  RFC9032:
   RFC9147:
   RFC9148:
   I-D.ietf-anima-constrained-voucher:
@@ -57,11 +56,11 @@ normative:
     author:
     rc: "IANA"
     date: 2021-10-19
+  RFC6690:
   RFC7252:
 
 informative:
   I-D.richardson-anima-state-for-joinrouter:
-  RFC6690:
   RFC7030:
   RFC7102:
   RFC7228:
@@ -74,6 +73,7 @@ informative:
   RFC8974:
   RFC6550:
   RFC8610:
+  RFC9032:
 
 --- abstract
 This document extends the work of Bootstrapping Remote Secure Key
@@ -112,7 +112,7 @@ Constrained devices which may be part of constrained networks {{RFC7228}}, typic
 
 CoAP can be run with the Datagram Transport Layer Security (DTLS) {{RFC6347}} as a security protocol for authenticity and confidentiality of the messages.
 This is known as the "coaps" scheme.
-A constrained version of EST, using Coap and DTLS, is described in {{RFC9148}}.
+A constrained version of EST, using CoAP and DTLS, is described in {{RFC9148}}.
 
 The {{I-D.ietf-anima-constrained-voucher}} extends {{RFC9148}} with BRSKI artifacts such as voucher, request voucher, and the protocol extensions for constrained Pledges that use CoAP.
 
@@ -150,9 +150,9 @@ This document is very much inspired by text published earlier in {{I-D.kumar-dic
 
 Similar to the difference between storing and non-storing Modes of
 Operations (MOP) in RPL {{RFC6550}}, the stateful and stateless modes differ in the way that they store
-the state required to forward the return packet to the pledge.
+the state required to forward the return packet to the Pledge.
 In the stateful method, the
-return forward state is stored in the join proxy.
+return forward state is stored in the Join Proxy.
 In the stateless method, the return forward state is stored in the network using the CoAP extended token in a way identical to that described in {{RFC9031}}.
 
 # Terminology          {#Terminology}
@@ -166,11 +166,7 @@ Registrar/Coordinator (JRC), Pledge, and Voucher.
 In this document, the term "Registrar" is used throughout instead of "Join
 Registrar/Coordinator (JRC)".
 
-The term "installation" refers to all devices in the network and their interconnections, including Registrar, enrolled nodes with and without constrained Join Proxy functionality and Pledges.
-
-(Installation) IP addresses are assumed to be routeable over the whole installation network except for the link-local IP addresses used at the edges where new pledges join.
-
-The "Constrained Join Proxy" enables a pledge that is multiple hops away from the Registrar, to execute the BRSKI protocol {{RFC8995}} using a secure channel.
+The "Constrained Join Proxy" enables a Pledge that is multiple hops away from the Registrar, to execute the BRSKI protocol {{RFC8995}} using a secure channel.
 
 The term "Join Proxy" is used interchangeably with the term "constrained Join Proxy" throughout this document.
 
@@ -212,9 +208,9 @@ An authenticated constrained Join Proxy can discover the routable IP address of 
 The following {{jr-spec}} specifies the two constrained Join Proxy modes.
 A comparison is presented in {{jr-comp}}.
 
-When a mesh network is set up, it consists of a Registrar and a set of connected pledges.
+When a mesh network is set up, it consists of a Registrar and a set of connected Pledges.
 No constrained Join Proxies are present.
-Only some of these pledges may be neighbors of the Registrar.
+Only some of these Pledges may be neighbors of the Registrar.
 Others would need for their traffic to be routed across one or more enrolled devices to reach the Registrar.
 
 The desired state of the installation is a network with a Registrar and all Pledges becoming enrolled devices.
@@ -225,7 +221,7 @@ The Pledges which are neighbors of the Registrar will discover the Registrar and
 An enrolled device can act as constrained Join Proxy.
 The Pledges which are not a neighbor of the Registrar will eventually discover a constrained Join Proxy and follow the constrained BRSKI protocol to be enrolled.
 While this goes on, more and more constrained Join Proxies with a larger hop distance to the Registrar will emerge.
-The network should be configured such that at the end of the enrollment process, all pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
+The network should be configured such that at the end of the enrollment process, all Pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
 
 The constrained Join Proxy is as a packet-by-packet proxy for UDP packets between Pledge and Registrar.
 The constrained BRSKI protocol between Pledge and Registrar described in {{I-D.ietf-anima-constrained-voucher}} which this Join Proxy supports uses UDP messages with DTLS payload, but the Join Proxy as described here is unaware of this payload.
@@ -244,8 +240,8 @@ A Join Proxy can operate in two modes:
 
 The advantages and disadvantages of the two modes are presented in {{jr-comp}}.
 
-A Join Proxy MUST implement both.
-A Registrar MUST implement the stateful mode and SHOULD implement the Stateless mode.
+A Registrar MUST implement both the stateful mode and the Stateless mode, but an operator MAY configure it to announce only one.
+A Join Proxy MUST implement the stateless mode, but SHOULD implement the stateful mode if it has sufficient memory.
 
 For a Join Proxy to be operational, the node on which it is running has to be
 able to talk to a Registrar (exchange UDP messages with it).
@@ -269,7 +265,7 @@ If the discovery method does not support discovery of the join-port, then the Pl
 
 In stateful mode, the Join Proxy acts as a UDP "circuit" proxy that does not change the UDP payload (data octets according to {{RFC768}}) but only rewrites the IP and UDP headers of each packet it receives from Pledge and Registrar.
 
-The stateful join proxy operates as a 'pseudo' UDP circuit proxy creating and utilizing connection mapping state to rewrite the IP address and UDP port number packet header fields of UDP packets that it forwards between Pledge and Registrar.
+The stateful Join Proxy operates as a 'pseudo' UDP circuit proxy creating and utilizing connection mapping state to rewrite the IP address and UDP port number packet header fields of UDP packets that it forwards between Pledge and Registrar.
 {{fig-statefull2}} depiects how this state is used.
 
 ~~~~
@@ -300,18 +296,24 @@ IP_Jr:p_Jr = Routable IP address and client port of Join Proxy
 ~~~~
 {: #fig-statefull2 title='constrained stateful joining message flow with Registrar address known to Join Proxy.' align="left"}
 
-Because UDP does not have the notion of a connection, this document calls this a 'pseudo' connection, whose establishment is solely triggered by receipt of a packet from a pledge with an IP_p%IF:p_P source for which no mapping state exists, and that is
+Because UDP does not have the notion of a connection, this document calls this a 'pseudo' connection, whose establishment is solely triggered by receipt of a packet from a Pledge with an IP_p%IF:p_P source for which no mapping state exists, and that is
 termined by a connection expiry timer E.
 
 If an untrusted Pledge that can only use link-local addressing wants to contact a trusted Registrar, and the Registrar is more than one hop away, it sends its DTLS messages to the Join Proxy.
 
+When a proxy receives an ICMP error message from the Registrar or Plege, for which mapping state exist, the proxy SHOULD map the ICMP message as it would map a UDP message and forward the ICMP message to the Registrar / Pledge.
+Processing of ICMP messages SHOULD NOT reset the connection expiry timer.
+
+To protect itself and the Registrar against malfunctioning Pledges and or denial of service attacks, the join proxy SHOULD limit the number of simultaneous mapping states on per ip address to 2 and the number of simultaneous mapping states per interface to 10.
+When mapping state can not be built due to exhausted state, the proxy SHOULD return an  ICMP error (1), "Destination Port Unreachable" message with code (1), "Communication with destination  administratively prohibited".
+
 ## Stateless Join Proxy {#jpy-encapsulation-protocol}
 
-Stateless join proxy operation eliminates the need and complexity to maintain per UDP connection mapping state on the proxy and the state machinery to build, maintain and
+Stateless Join Proxy operation eliminates the need and complexity to maintain per UDP connection mapping state on the proxy and the state machinery to build, maintain and
 remove this mapping state.
 It also removes the need to protect this mapping state against DoS attacks and may also reduce memory and CPU requirements on the proxy.
 
-Stateless join proxy operations works by encapsulating the DTLS messages into a new CoAP header {{RFC7252}}.
+Stateless Join Proxy operations works by encapsulating the DTLS messages into a new CoAP header {{RFC7252}}.
 This new CoAP header is designed to be as minimalistic as possible.
 The use of CoAP here costs a XXX bytes more than a custom encapsulation, but simplies much of the operation, as well as permitting the result to pass through CoAP proxies, CoAP to HTTP proxies, and other mechanisms that might be introduced into a network.
 This also eliminates custom code that is only rarely used, which may reduce bugs.
@@ -328,18 +330,18 @@ The CoAP payload is configured much as {{RFC9031, Section 8.1.1}} specifies:
 
    * No Uri-Path option is included.
 
-   * The payload is the DTLS payload as received from the pledge.
+   * The payload is the DTLS payload as received from the Pledge.
 
-   * An extended token {{RFC8974}} is included to contain some encrypted state that allows replies to be returned to the pledge.
+   * An extended token {{RFC8974}} is included to contain some encrypted state that allows replies to be returned to the Pledge.
 
 {{coap-breakout}} shows an example CoAP header, assuming a 16-byte extended token, with the resulting overhead of 28 bytes.
 
-When the join proxy receives a UDP message from a Pledge, it encodes the Pledges link-local IP address, interface and UDP (source) port of the packet into the extended token.
+When the Join Proxy receives a UDP message from a Pledge, it encodes the Pledges link-local IP address, interface and UDP (source) port of the packet into the extended token.
 The result is sent to the Registrar from a fixed source UDP port.
 
 As described in {{RFC7252, Section 5.3.1}}, when the Registrar sends packets for the Pledge, it MUST return the token field unchanged.
-This allows the join proxy to decode the saved pledge state, and reconstruct the Pledges link-local IP address, interace and UDP (destination) port for the return packet.
-{{fig-stateless}} shows this per-packet mapping on the join proxy.
+This allows the Join Proxy to decode the saved Pledge state, and reconstruct the Pledges link-local IP address, interace and UDP (destination) port for the return packet.
+{{fig-stateless}} shows this per-packet mapping on the Join Proxy.
 
 The Registrar transiently stores the extended token field information in case it needs to generate additional messages as a result of DTLS processing.
 
@@ -351,7 +353,7 @@ The Header contains the original source link-local address and port of the Pledg
 On receiving the CoAP message, the Join Proxy processes the CoAP header.
 It uses the extended token field to route the payload as a DTLS message to the Pledge.
 
-In the stateless join proxy mode, both the Registrar and the Join Proxy use discoverable UDP join-ports.
+In the stateless Join Proxy mode, both the Registrar and the Join Proxy use discoverable UDP join-ports.
 For the Join Proxy this may be a default CoAP port.
 
 ~~~~
@@ -415,14 +417,14 @@ The context that is stored into the extended token might be constructed with the
 This results in a total of 96 bits, or 12 bytes.
 The structure stores the srcport, the originating IPv6 Link-Local address, the IPv4/IPv6 family (as a single bit) and an ifindex to provide the link-local scope.
 This fits nicely into a single AES128 CBC block for instance, resulting in a 16 byte token.
-The Join Proxy MUST maintain the same context block for all communications from the same pledge.
+The Join Proxy MUST maintain the same context block for all communications from the same Pledge.
 This implies that any encryption key either does not change during the communication, or that when it does, it is acceptable to break any onboarding connections which have not yet completed.
-If using a context parameter like defined above, it should be easy for the Join Proxy to meet this requirement without maintaining any local state about the pledge.
+If using a context parameter like defined above, it should be easy for the Join Proxy to meet this requirement without maintaining any local state about the Pledge.
 
 Note: when IPv6 is used only the lower 64-bits of the origin IP need to be recorded, because they are all IPv6 Link-Local addresses, so the upper 64-bits are just "fe80::". For IPv4, a Link-Local IPv4 address {{?RFC3927}} would be used, and it would fit into 64-bits.
 On media where the IID is not 64-bits, a different arrangement will be necessary.
 
-For the join messages relayed to a particular Registrar, the Join Proxy SHOULD use the same UDP source port for all messages related to all pledges.
+For the join messages relayed to a particular Registrar, the Join Proxy SHOULD use the same UDP source port for all messages related to all Pledges.
 A Join Proxy MAY change the UDP source port, but doing so creates more local state.
 But, a Join Proxy with multiple CPUs (unlikely in a constrained system, but possible in some future) could, for instance, use different source port numbers to demultiplex connections across CPUs.
 
@@ -466,7 +468,7 @@ Upon success, the return payload will contain a port that contain process the Co
 In the {{RFC6690}} link format, and {{?RFC3986, Section 3.2}}, the authority attribute can not include a port number unless it also includes the IP address.
 
 The returned join-port is expected to process the CoAP encapsulated DTLS messages described in section {{stateless-jpy}}.
-The scheme is now coap, as the outside protocol is CoAP and could be subject to further CoAP operations.
+The scheme is now CoAP, as the outside protocol is CoAP and could be subject to further CoAP operations.
 
 An EST/Registrar server running at address ```2001:db8:0:abcd::52```, with the
 CoAP processing on port 7634, and the stateful Registrar on port 5683 could reply to a multicast query as follows:
@@ -476,6 +478,7 @@ CoAP processing on port 7634, and the stateful Registrar on port 5683 could repl
 
   RES: 2.05 Content
   <coap://[2001:db8:0:abcd::52]:7634>;rt=brski.rjp,
+  <coaps://[2001:db8:0:abcd::52]/.well-known/brski>;rt=brski,
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/rv>;rt=brski.rv;ct=836,
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/vs>;rt=brski.vs;ct="50 60",
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/es>;rt=brski.es;ct="50 60",
@@ -485,7 +488,7 @@ CoAP processing on port 7634, and the stateful Registrar on port 5683 could repl
 
 {{Section 10.2.1 of I-D.ietf-anima-constrained-voucher}} describes how to use GRASP {{RFC8990}} discovery within the ACP to locate the stateful port of the Registrar.
 
-A join proxy which supports a stateless mode of operation using the mechanism described in {{stateless-jpy}} must know where to send the encoded content from the pledge.
+A Join Proxy which supports a stateless mode of operation using the mechanism described in {{stateless-jpy}} must know where to send the encoded content from the Pledge.
 The Registrar announces its willingness to use the stateless mechanism by including an additional objective in it's M\_FLOOD'ed ```AN_join_registrar``` announcements, but with a different objective value.
 
 The following changes are necessary with respect to figure 10 of {{RFC8995}}:
@@ -518,7 +521,7 @@ Most Registrars will announce both a CoAP-stateless and stateful ports, and may 
     [O_IPv6_LOCATOR,
      h'fda379a6f6ee00000200000064000001', IPPROTO_UDP, 5685]]]
 ~~~
-{: #fig-grasp-many title='Example of Registrar announcing two services' align="left"}
+{: #fig-grasp-many title='Example of Registrar announcing three services' align="left"}
 
 ## Pledge discovers Join-Proxy
 
@@ -527,7 +530,7 @@ When doing constrained onboarding with DTLS as security, the Pledge will always 
 
 ### CoAP discovery {#jp-disc}
 
-In the context of a coap network without Autonomic Network support, discovery follows the standard coap policy.
+In the context of a CoAP network without Autonomic Network support, discovery follows the standard CoAP policy.
 The Pledge can discover a Join Proxy by sending a link-local multicast message to ALL CoAP Nodes with address FF02::FD. Multiple or no nodes may respond.
 The handling of multiple responses and the absence of responses follow section 4 of {{RFC8995}}.
 
@@ -544,7 +547,7 @@ The example below shows the discovery of the join-port of the Join Proxy.
 ~~~~
 
 Port numbers are assumed to be the default numbers 5683 and 5684 for coap and coaps respectively (sections 12.6 and 12.7 of {{RFC7252}}) when not shown in the response.
-Discoverable port numbers are usually returned for Join Proxy resources in the &lt;URI-Reference&gt; of the payload (see section 5.1 of {{RFC9148}}).
+Discoverable port numbers are usually returned for Join Proxy resources in the &lt;URI-Reference&gt; of the payload (see section 4.1 of {{RFC9148}}).
 
 ### GRASP discovery
 
@@ -580,37 +583,16 @@ The discovery of Join-Proxy by the Pledge uses the enhanced beacons as discussed
 The stateful and stateless mode of operation for the Join Proxy have their advantages and disadvantages.
 This section should enable operators to make a choice between the two modes based on the available device resources and network bandwidth.
 
-~~~~
-+-------------+----------------------------+------------------------+
 | Properties  |         Stateful mode      |     Stateless mode     |
-+-------------+----------------------------+------------------------+
-| State       |The Join Proxy needs        | No information is      |
-| Information |additional storage to       | maintained by the Join |
-|             |maintain mapping between    | Proxy. Registrar needs |
-|             |the address and port number | to store the packet    |
-|             |of the Pledge and those     | header.                |
-|             |of the Registrar.           |                        |
-+-------------+----------------------------+------------------------+
-|Packet size  |The size of the forwarded   |Size of the forwarded   |
-|             |message is the same as the  |message is bigger than  |
-|             |original message.           |the original,it includes|
-|             |                            |additional information  |
-+-------------+----------------------------+------------------------+
-|Specification|The Join Proxy needs        |CoAP message to         |
-|complexity   |additional functionality    |encapsulate DTLS payload|
-|             |to maintain state           |The Registrar           |
-|             |information, and specify    |and the Join Proxy      |
-|             |the source and destination  |have to understand the  |
-|             |addresses of the DTLS       |CoAP header in order    |
-|             |handshake messages          |to process it.          |
-+-------------+----------------------------+------------------------+
-| Ports       | Join Proxy needs           |Join Proxy and Registrar|
-|             | discoverable join-port     |need discoverable       |
-|             |                            | join-ports             |
-+-------------+----------------------------+------------------------+
-
-~~~~
-{: #fig-comparison title='Comparison between stateful and stateless mode' align="left"}
+|:----------- |:---------------------------|:-----------------------|
+| State Information |The Join Proxy needs additional storage to maintain mapping between the address and port number of the Pledge and those of the Registrar.  | No information is maintained by the Join Proxy. Registrar needs to store the packet  header.  |
+|-------------
+|Packet size  |The size of the forwarded message is the same as the original message.   |Size of the forwarded message is bigger than the original, it includes additional information  |
+|-------------
+|Specification complexity |The Join Proxy needs additional functionality to maintain state information, and specify the source and destination addresses of the DTLS handshake messages       |CoAP message to encapsulate DTLS payload. The Registrar and the Join Proxy have to understand the CoAP header in order to process it.          |
+|------------
+| Ports       | Join Proxy needs discoverable join-port |Join Proxy and Registrar need discoverable join-ports             |
+|=============
 
 # Security Considerations
 
@@ -626,7 +608,7 @@ A malicious constrained Join Proxy has a number of routing possibilities:
 
    * It uses the returned response of the Registrar to enroll itself in the network. With very low probability it can decrypt the response because successful enrollment is deemed  unlikely.
 
-   * It uses the request from the pledge to appropriate the pledge certificate, but then it still needs to acquire the private key of the pledge. This, too, is assumed to be highly unlikely.
+   * It uses the request from the Pledge to appropriate the Pledge certificate, but then it still needs to acquire the private key of the Pledge. This, too, is assumed to be highly unlikely.
 
    * A malicious node can construct an invalid Join Proxy message.
 Suppose, the destination port is the coaps port.
@@ -641,18 +623,15 @@ A malicious node can read the header field of the message sent by the stateless 
 This ability does not yield much more information than the visible addresses transported in the network packets.
 
 It should be noted here that the contents of the CBOR array used to convey return address information is not DTLS protected.
-When the communication between JOIN Proxy and Registrar passes over an unsecure network, an attacker can change the CBOR array, causing the Registrar to deviate traffic from the intended Pledge.
+When the communication between Join Proxy and Registrar passes over an unsecure network, an attacker can change the CBOR array, causing the Registrar to deviate traffic from the intended Pledge.
 These concerns are also expressed in {{RFC8974}}.
-It is also pointed out that the encryption in the source is a local matter.
+It is also pointed out that the encryption by the Join Proxy is a local matter.
 Similarly to {{RFC8974}}, the use of AES-CCM {{RFC3610}} with a 64-bit tag is recommended, combined with a sequence number and a replay window.
 
 If such scenario needs to be avoided, the constrained Join Proxy MUST encrypt the CBOR array using a locally generated symmetric key.
 The Registrar is not able to examine the encrypted result, but does not need to.
 The Registrar stores the encrypted header in the return packet without modifications.
 The constrained Join Proxy can decrypt the contents to route the message to the right destination.
-
-In some installations, layer 2 protection is provided between all member pairs of the mesh.
-In such an environment encryption of the CBOR array is unnecessary because the layer 2 protection already provide it.
 
 # IANA Considerations
 
@@ -806,8 +785,7 @@ A CBOR header would have taken 4+16 bytes or 20 bytes, for a difference of 8 byt
 
 The examples show the request "GET coaps://192.168.1.200:5965/est/crts" to a Registrar. The header generated between Join Proxy and Registrar and from Registrar to Join Proxy are shown in detail. The DTLS payload is not shown.
 
-
-
+NOTE THESE ARE OLD.
 
 The request from Join Proxy to Registrar looks like:
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -212,7 +212,21 @@ This constrained Join Proxy functionality is also (auto) configured into all aut
 The constrained Join Proxy allows for routing of the packets from the Pledge using IP routing to the intended Registrar. An authenticated constrained Join Proxy can discover the routable IP address of the Registrar over multiple hops.
 The following {{jr-spec}} specifies the two constrained Join Proxy modes. A comparison is presented in {{jr-comp}}.
 
-When a mesh network is set up, it consists of a Registrar and a set of connected pledges. No constrained Join Proxies are present. The wanted end-state is a network with a Registrar and a set of enrolled devices. Some of these enrolled devices can act as constrained Join Proxies. Pledges can only employ link-local communication until they are enrolled. A Pledge will regularly try to discover a constrained Join Proxy or a Registrar with link-local discovery requests. The Pledges which are neighbors of the Registrar will discover the Registrar and be enrolled following the BRSKI protocol. An enrolled device can act as constrained Join Proxy. The Pledges which are not a neighbor of the Registrar will eventually discover a constrained Join Proxy and follow the BRSKI protocol to be enrolled. While this goes on, more and more constrained Join Proxies with a larger hop distance to the Registrar will emerge. The network should be configured such that at the end of the enrollment process, all pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
+When a mesh network is set up, it consists of a Registrar and a set of connected pledges. No constrained Join Proxies are present.  Only some of these pledges may be neighbors of the Registrar. Others would need for their traffic to be routed across one or more enrolled devices to reach the Registrar.
+
+The desired state of the installation is a network with a Registrar and all Pledges becoming enrolled devices. Some of these enrolled devices can act as constrained Join Proxies. Pledges can only employ link-local communication until they are enrolled. A Pledge will regularly try to discover a constrained Join Proxy or a Registrar with link-local discovery requests. The Pledges which are neighbors of the Registrar will discover the Registrar and be enrolled following the constrained BRSKI protocol. An enrolled device can act as constrained Join Proxy. The Pledges which are not a neighbor of the Registrar will eventually discover a constrained Join Proxy and follow the constrained BRSKI protocol to be enrolled. While this goes on, more and more constrained Join Proxies with a larger hop distance to the Registrar will emerge. The network should be configured such that at the end of the enrollment process, all pledges have discovered a neighboring constrained Join Proxy or the Registrar, and all Pledges are enrolled.
+
+The constrained Join Proxy is as a packet-by-packet proxy for UDP packets between Pledge and
+Registrar. The constrained BRSKI protocol between Pledge and Registrar described in
+{{I-D.ietf-anima-constrained-voucher}} which this Join Proxy supports
+uses UDP messages with DTLS payload, but the Join Proxy as described here is unaware
+of this payload. It can therefore potentially also work for other UDP based protocols
+as long as they are agnostic to (or can be made to work with) the change of IP header
+by the constrained Join Proxy.
+
+In both Stateless and Stateful mode, the Join Proxy needs to be configured with
+or dynamically discover a Registrar to perform its service. This specification does not
+discuss how a constrained Join Proxy selects a Registrar when it discovers 2 or more.
 
 # constrained Join Proxy specification {#jr-spec}
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -202,12 +202,13 @@ If the Pledge, knowing the IP-address of the Registrar, initiates a DTLS connect
 ~~~~
 {: #fig-net title='multi-hop enrollment.' align="left"}
 
-Without routing the Pledge cannot establish a secure connection to the Registrar over multiple hops in the network.
+Without a routeable IPv6 address, the Pledge (P) cannot exchange IPv6/UDP/DTLS traffic
+with the Registrar (R), over multiple hops in the network.
 
-Furthermore, the Pledge cannot discover the IP address of the Registrar over multiple hops to initiate a DTLS connection and perform authentication.
+Furthermore, the Pledge may not be able to discover the IP address of the Registrar over multiple hops to initiate a DTLS connection and perform authentication.
 
 To overcome the problems with non-routability of DTLS packets and/or discovery of the destination address of the Registrar, the constrained Join Proxy is introduced.
-This constrained Join Proxy functionality is configured into all authenticated devices in the network which may act as a constrained Join Proxy for Pledges.
+This constrained Join Proxy functionality is also (auto) configured into all authenticated devices in the network which may act as a constrained Join Proxy for Pledges.
 The constrained Join Proxy allows for routing of the packets from the Pledge using IP routing to the intended Registrar. An authenticated constrained Join Proxy can discover the routable IP address of the Registrar over multiple hops.
 The following {{jr-spec}} specifies the two constrained Join Proxy modes. A comparison is presented in {{jr-comp}}.
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -235,21 +235,38 @@ A Join Proxy can operate in two modes:
   * Stateful mode
   * Stateless mode
 
-A Join Proxy MUST implement both. A Registrar MUST implement the stateful mode and SHOULD implement the Stateless mode.
-
-A mechanism to switch between modes is out of scope of this document. It is recommended that a Join Proxy uses only one of these modes at any given moment during an installation lifetime.
-
 The advantages and disadvantages of the two modes are presented in {{jr-comp}}.
 
-## Stateful Join Proxy
+A Join Proxy MUST implement both. A Registrar MUST implement the stateful mode and SHOULD implement the Stateless mode.
 
-In stateful mode, the Join Proxy forwards the DTLS messages to the Registrar.
+For a Join Proxy to be operational, the node on which it is running has to be
+able to talk to a Registrar (exchange UDP messages with it). This can happen
+fully automatically by the Join Proxy node first enrolling itself as a Pledge,
+and then learning the IP address, the UDP port and the mode(s) (Stateful and/or Stateless)
+of the Registrar, through a discovery mechanism such as those described in Section 6.
+Other methods, such as provisioning the Join Proxy are out of scope of this document
+but equally feasible.
+
+Once the Join Proxy is operational, its mode is determined by the mode of the Registrar.
+If the Registrar offers both Stateful and Stateless mode, the Join Proxy MUST use
+the stateless mode.
+
+Independent of the mode of the Join Proxy, the Pledge first discovers (see Section 6)
+and selects the most appropriate Join Proxy. From the discovery, the Pledge learns the
+Join Proxies link-local scope IP address and UDP (join) port.  This discovery can also be
+based upon {{RFC8995}} section 4.1.  If the discovery method does not support discovery
+of the join-port, then the Pledge assumes the default CoAP over DTLS UDP port (5683).
+
+## Stateful Join Proxy {#stateful}
 
 In stateful mode, the Join Proxy acts as a UDP "circuit" proxy that does not
 change the UDP payload (data octets according to {{RFC768}}) but only rewrites
 the IP and UDP headers of each packet it receives from Pledge and Registrar.
 
-In {{fig-statefull2}} the various steps of the message flow are shown, with 5684 being the standard coaps port. The columns "SRc_IP:port" and "Dst_IP:port" show the IP address and port values for the source and destination of the message.
+The stateful join proxy operates as a 'pseudo' UDP circuit proxy creating
+and utilizing connection mapping state to rewrite the IP address and UDP port number
+packet header fields of UDP packets that it forwards between Pledge and Registrar.
+{{fig-statefull2}} depiects how this state is used.
 
 ~~~~
 +------------+------------+-------------+--------------------------+

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -451,38 +451,35 @@ In order to accomodate automatic configuration of the Join-Proxy, it must discov
 ### CoAP discovery {#coap-disc}
 
 {{Section 10.2.2 of I-D.ietf-anima-constrained-voucher}} describes how to use CoAP Discovery.
-The stateless Join Proxy requires a different end point that can accept the JPYencapsulation.
+The stateless Join Proxy requires a different end point that can accept the second CoAP header encapsulation and extended token.
 
 The stateless Join Proxy can discover the join-port of the Registrar by sending a GET request to "/.well-known/core" including a resource type (rt) parameter with the value "brski.rjp" {{RFC6690}}.
-Upon success, the return payload will contain the join-port of the Registrar.
+Upon success, the return payload will contain a port that contain process the CoAP encalsulated DTLS messages.
 
 ~~~~
   REQ: GET /.well-known/core?rt=brski.rjp
 
   RES: 2.05 Content
-  <coaps+jpy://[IP_address]:join-port>;rt=brski.rjp
+  <coap://[IP_address]:join-port>;rt=brski.rjp
 ~~~~
 
 In the {{RFC6690}} link format, and {{?RFC3986, Section 3.2}}, the authority attribute can not include a port number unless it also includes the IP address.
 
-The returned join-port is expected to process the encapsulated JPY messages described in section {{stateless-jpy}}.
-The scheme remains coaps, as the inside protocol is still CoAP and DTLS.
+The returned join-port is expected to process the CoAP encapsulated DTLS messages described in section {{stateless-jpy}}.
+The scheme is now coap, as the outside protocol is CoAP and could be subject to further CoAP operations.
 
-An EST/Registrar server running at address ```2001:db8:0:abcd::52```, with the JPY process on port 7634, and the stateful Registrar on port 5683 could reply to a multicast query as follows:
+An EST/Registrar server running at address ```2001:db8:0:abcd::52```, with the
+CoAP processing on port 7634, and the stateful Registrar on port 5683 could reply to a multicast query as follows:
 
 ~~~~
   REQ: GET /.well-known/core?rt=brski*
 
   RES: 2.05 Content
-  <coaps+jpy://[2001:db8:0:abcd::52]:7634>;rt=brski.rjp,
+  <coap://[2001:db8:0:abcd::52]:7634>;rt=brski.rjp,
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/rv>;rt=brski.rv;ct=836,
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/vs>;rt=brski.vs;ct="50 60",
   <coaps://[2001:db8:0:abcd::52]/.well-known/brski/es>;rt=brski.es;ct="50 60",
 ~~~~
-
-
-
-The coaps+jpy scheme is registered is defined in {{jpyscheme}}, as per {{RFC7252, Section 6.2}}
 
 ### GRASP discovery
 
@@ -507,7 +504,7 @@ Here is an example M\_FLOOD announcing the Registrar on example port 5685, which
 ~~~
 {: #fig-grasp-rgj title='Example of Registrar announcement message' align="left"}
 
-Most Registrars will announce both a JPY-stateless and stateful ports, and may also announce an HTTPS/TLS service:
+Most Registrars will announce both a CoAP-stateless and stateful ports, and may also announce an HTTPS/TLS service:
 
 ~~~
    [M_FLOOD, 51840231, h'fda379a6f6ee00000200000064000001', 180000,
@@ -599,12 +596,12 @@ This section should enable operators to make a choice between the two modes base
 |             |original message.           |the original,it includes|
 |             |                            |additional information  |
 +-------------+----------------------------+------------------------+
-|Specification|The Join Proxy needs        |New JPY message to      |
+|Specification|The Join Proxy needs        |CoAP message to         |
 |complexity   |additional functionality    |encapsulate DTLS payload|
 |             |to maintain state           |The Registrar           |
 |             |information, and specify    |and the Join Proxy      |
 |             |the source and destination  |have to understand the  |
-|             |addresses of the DTLS       |JPY message in order    |
+|             |addresses of the DTLS       |CoAP header in order    |
 |             |handshake messages          |to process it.          |
 +-------------+----------------------------+------------------------+
 | Ports       | Join Proxy needs           |Join Proxy and Registrar|
@@ -675,21 +672,6 @@ Parameters" registry per the {{RFC6690}} procedure.
                  Join Proxy to query and return Join Proxy specific
                  BRSKI resources of a Registrar.
     Reference: [this document]
-
-## CoAPS+JPY Scheme Registration {#jpyscheme}
-
-
-    Scheme name: coaps+jpy
-    Status: permanent
-    Applications/protocols that use this scheme name: Constrained BRSKI Join Proxy
-    Contact: ANIMA WG
-    Change controller: IESG
-    References: [THIS RFC]
-    Scheme syntax: identical to coaps
-    Scheme semantics: The encapsulation mechanism described in {{stateless-jpy}} is used with coaps.
-    Security considerations: The new encapsulation allows traffic to be returned to a calling node
-       behind a proxy.  The form of the encapsulation can include privacy and integrity protection
-       under the control of the proxy system.
 
 ## service name and port number registry {#dns-sd-spec}
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -708,13 +708,19 @@ This specification registers two service names under the "Service Name and Trans
 
 # Acknowledgements
 
-Many thanks for the comments by {{{Carsten Bormann}}}, {{{Brian Carpenter}}}, {{{Spencer Dawkins}}}, {{{Esko Dijk}}}, {{{Toerless Eckert}}}, {{{Russ Housley}}}, {{{Ines Robles}}}, {{{Rich Salz}}}, {{{Jürgen Schönwälder}}}, {{{Mališa Vučinić}}}, and {{{Rob Wilton}}}.
+Many thanks for the comments by {{{Carsten Bormann}}}, {{{Brian Carpenter}}},
+{{{Spencer Dawkins}}}, {{{Esko Dijk}}}, {{{Toerless Eckert}}}, {{{Russ Housley}}}, {{{Ines Robles}}}, {{{Rich Salz}}}, {{{Jürgen Schönwälder}}}, {{{Mališa Vučinić}}}, and {{{Rob Wilton}}}.
 
 # Contributors
 
-{{{Sandeep Kumar}}}, {{{Sye loong Keoh}}}, and {{{Oscar Garcia-Morchon}}} are the co-authors of the draft-kumar-dice-dtls-relay-02. Their draft has served as a basis for this document. Much text from their draft is copied over to this draft.
+{{{Sandeep Kumar}}}, {{{Sye loong Keoh}}}, and {{{Oscar Garcia-Morchon}}} are the co-authors of the draft-kumar-dice-dtls-relay-02.
+Their draft has served as a basis for this document.
 
 # Changelog
+
+## 14 to 13
+   * incorporated review comments from TTE
+   * jpy message changed to CoAP header
 
 ## 13 to 12
     * jpy message encrypted and no longer standardized

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -157,6 +157,8 @@ In the stateless method, the return forward state is stored in the network using
 
 # Terminology          {#Terminology}
 
+{::boilerplate bcp14}
+
 The following terms are defined in {{RFC8366}}, and are used
 identically as in that document: artifact, imprint, domain, Join
 Registrar/Coordinator (JRC), Pledge, and Voucher.
@@ -173,10 +175,6 @@ The "Constrained Join Proxy" enables a pledge that is multiple hops away from th
 The term "join Proxy" is used interchangeably with the term "constrained Join Proxy" throughout this document.
 
 The {{RFC8995}} Circuit Proxy is referred to as a TCP circuit Join Proxy.
-
-# Requirements Language {#reqlang}
-
-{::boilerplate bcp14}
 
 # constrained Join Proxy functionality
 

--- a/draft-ietf-anima-constrained-join-proxy.md
+++ b/draft-ietf-anima-constrained-join-proxy.md
@@ -35,6 +35,7 @@ venue:
   github: anima-wg/constrained-join-proxy
 
 normative:
+  RFC768:
   RFC6347:
   RFC8366:
   RFC8995:
@@ -211,12 +212,9 @@ The advantages and disadvantages of the two modes are presented in {{jr-comp}}.
 
 In stateful mode, the Join Proxy forwards the DTLS messages to the Registrar.
 
-Assume that the Pledge does not know the IP address of the Registrar it needs to contact.
-The Join Proxy has been enrolled via the Registrar and learns the IP address and port of the Registrar, by using a discovery mechanism such as described in {{jr-disc}}. The Pledge first discovers (see {{jr-disc}}) and selects the most appropriate Join Proxy.
-(Discovery can also be based upon {{RFC8995}} section 4.1).
-The Pledge initiates its request as if the Join Proxy is the intended Registrar. The Join Proxy receives the message at a discoverable join-port.
-The Join Proxy constructs an IP packet by copying the DTLS payload from the message received from the Pledge, and provides source and destination addresses to forward the message to the intended Registrar.
-The Join Proxy stores the 4-tuple array of the messages received from the Registrar and copies it back to the header of the message returned to the Pledge.
+In stateful mode, the Join Proxy acts as a UDP "circuit" proxy that does not
+change the UDP payload (data octets according to {{RFC768}}) but only rewrites
+the IP and UDP headers of each packet it receives from Pledge and Registrar.
 
 In {{fig-statefull2}} the various steps of the message flow are shown, with 5684 being the standard coaps port. The columns "SRc_IP:port" and "Dst_IP:port" show the IP address and port values for the source and destination of the message.
 


### PR DESCRIPTION
The branch 'coap-as-jpy' was used a while ago as a working branch for editorial changes.

This PR is to get that work integrated into main again.